### PR TITLE
feat: Add subscription support and fix polling reliability

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -261,15 +261,35 @@ module.exports = function (self) {
 			callback: async (event) => {
 				const cmd = await self.parseVariablesInString(event.options.command)
 
-				//Check for subscribe command so we can grab the variable name
+				//Check for subscribe/unsubscribe command
 				var cmdTokens = cmd.split(' ')
 				if (cmdTokens[1].toLowerCase() == 'subscribe') {
-					//Add the custom variable to the subscribeVars array
 					var varName = cmdTokens.reverse()[1]
-					self.subscribeVars.push({ name: varName, roundVal: event.options.roundval })
+					var unsubCmd = cmd.replace(/\bsubscribe\b/, 'unsubscribe')
+
+					// Track for rounding (upsert)
+					var existingVarIdx = self.subscribeVars.findIndex((obj) => obj.name === varName)
+					if (existingVarIdx > -1) {
+						self.subscribeVars[existingVarIdx] = { name: varName, roundVal: event.options.roundval }
+					} else {
+						self.subscribeVars.push({ name: varName, roundVal: event.options.roundval })
+					}
+
+					// Track for reconnect (upsert)
+					var existingSubIdx = self.subscriptions.findIndex((obj) => obj.varName === varName)
+					if (existingSubIdx > -1) {
+						self.subscriptions[existingSubIdx] = { varName, cmd, unsubCmd }
+					} else {
+						self.subscriptions.push({ varName, cmd, unsubCmd })
+					}
 				} else if (cmdTokens[1].toLowerCase() == 'unsubscribe') {
-					//Remove the custom variable from the subscribeVars array
 					var varName = cmdTokens.reverse()[0]
+
+					let subIdx = self.subscriptions.findIndex((obj) => obj.varName === varName)
+					if (subIdx > -1) {
+						self.subscriptions.splice(subIdx, 1)
+					}
+
 					let varIdx = self.subscribeVars.findIndex((obj) => obj.name === varName)
 					if (varIdx > -1) {
 						self.subscribeVars.splice(varIdx, 1)

--- a/actions.js
+++ b/actions.js
@@ -426,5 +426,182 @@ module.exports = function (self) {
 				self.log('info', 'Poll once command (' + event.options.customvar + '): ' + event.options.command)
 			},
 		},
+		subscribeParameter: {
+			name: 'Subscribe to Parameter',
+			options: [
+				{
+					type: 'static-text',
+					id: 'info',
+					width: 12,
+					label:
+						'Subscribe to a parameter so the Tesira pushes updates automatically when the value changes. Much more responsive than polling.',
+					value: '',
+				},
+				{
+					type: 'textinput',
+					id: 'instanceID',
+					label: 'Instance Tag',
+					tooltip: 'Instance Tag of the block (e.g. MyMatrix)',
+					default: 'Level1',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'attribute',
+					label: 'Attribute',
+					tooltip: 'Attribute name - case sensitive (e.g. level, mute, crosspointLevelState)',
+					default: 'level',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'index',
+					label: 'Index',
+					tooltip: 'Index value (e.g. channel number)',
+					default: '1',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'customvar',
+					label: 'Variable Name',
+					tooltip: 'Custom variable name to store the value (also used as publishToken)',
+					default: 'MyVar',
+					width: 6,
+				},
+				{
+					type: 'textinput',
+					id: 'rate',
+					label: 'Rate (ms)',
+					tooltip: 'Minimum update interval in milliseconds',
+					default: '500',
+					width: 6,
+				},
+				{
+					type: 'checkbox',
+					id: 'roundval',
+					label: 'Round numeric values to nearest whole number',
+					default: true,
+				},
+				{
+					type: 'checkbox',
+					id: 'getInitial',
+					label: 'Get initial value on subscribe',
+					default: true,
+				},
+			],
+			callback: async (event) => {
+				const instanceID = (await self.parseVariablesInString(event.options.instanceID)).trim()
+				const attribute = (await self.parseVariablesInString(event.options.attribute)).trim()
+				const index = (await self.parseVariablesInString(event.options.index)).trim()
+				const varName = event.options.customvar.trim()
+				const rate = event.options.rate.trim()
+
+				if (!varName) {
+					self.log('error', 'Subscribe: Variable Name cannot be empty')
+					return
+				}
+
+				const cmd = instanceID + ' subscribe ' + attribute + ' ' + index + ' "' + varName + '" ' + rate
+				const unsubCmd = instanceID + ' unsubscribe ' + attribute + ' ' + index + ' "' + varName + '"'
+
+				// Update or add tracking for rounding (prevent duplicates)
+				const existingVarIdx = self.subscribeVars.findIndex((obj) => obj.name === varName)
+				if (existingVarIdx > -1) {
+					self.subscribeVars[existingVarIdx] = { name: varName, roundVal: event.options.roundval }
+				} else {
+					self.subscribeVars.push({ name: varName, roundVal: event.options.roundval })
+				}
+
+				// Update or add tracking for reconnect (prevent duplicates)
+				const existingSubIdx = self.subscriptions.findIndex((obj) => obj.varName === varName)
+				if (existingSubIdx > -1) {
+					self.subscriptions[existingSubIdx] = { varName, cmd, unsubCmd }
+				} else {
+					self.subscriptions.push({ varName, cmd, unsubCmd })
+				}
+
+				self.sendCommand(cmd)
+				self.log('info', 'Subscribed to ' + varName + ': ' + cmd)
+
+				// Get initial value via poll queue
+				if (event.options.getInitial) {
+					const getCmd = instanceID + ' get ' + attribute + ' ' + index
+					self.pollingCmds.push({
+						varName: varName,
+						roundVal: event.options.roundval,
+						cmd: getCmd,
+						runOnce: true,
+					})
+					self.debugLog('Queued initial GET: ' + getCmd)
+				}
+			},
+		},
+		unsubscribeParameter: {
+			name: 'Unsubscribe from Parameter',
+			options: [
+				{
+					type: 'textinput',
+					id: 'instanceID',
+					label: 'Instance Tag',
+					tooltip: 'Instance Tag of the block',
+					default: 'Level1',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'attribute',
+					label: 'Attribute',
+					tooltip: 'Attribute name',
+					default: 'level',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'index',
+					label: 'Index',
+					tooltip: 'Index value',
+					default: '1',
+					width: 6,
+					useVariables: true,
+				},
+				{
+					type: 'textinput',
+					id: 'customvar',
+					label: 'Variable Name',
+					tooltip: 'The variable name / publishToken used when subscribing',
+					default: 'MyVar',
+					width: 6,
+				},
+			],
+			callback: async (event) => {
+				const varName = event.options.customvar.trim()
+
+				// Use stored unsubCmd to ensure it exactly matches what was subscribed
+				let subIdx = self.subscriptions.findIndex((obj) => obj.varName === varName)
+				if (subIdx > -1) {
+					self.sendCommand(self.subscriptions[subIdx].unsubCmd)
+					self.subscriptions.splice(subIdx, 1)
+				} else {
+					// Fallback: reconstruct command if not tracked (e.g. subscribed via customCommand)
+					const instanceID = (await self.parseVariablesInString(event.options.instanceID)).trim()
+					const attribute = (await self.parseVariablesInString(event.options.attribute)).trim()
+					const index = (await self.parseVariablesInString(event.options.index)).trim()
+					self.sendCommand(instanceID + ' unsubscribe ' + attribute + ' ' + index + ' "' + varName + '"')
+				}
+
+				let varIdx = self.subscribeVars.findIndex((obj) => obj.name === varName)
+				if (varIdx > -1) {
+					self.subscribeVars.splice(varIdx, 1)
+				}
+
+				self.log('info', 'Unsubscribed from ' + varName)
+			},
+		},
 	})
 }

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ class TesiraInstance extends InstanceBase {
 		this.pollingInProgress = false
 		this.POLL_TIMEOUT_MS = 5000
 		this.subscribeVars = []
+		this.subscriptions = []
 
 		this.debugLog('Init')
 
@@ -35,6 +36,13 @@ class TesiraInstance extends InstanceBase {
 
 	// When module gets deleted
 	async destroy() {
+		// Unsubscribe all active subscriptions before disconnecting
+		for (const sub of this.subscriptions) {
+			this.sendCommand(sub.unsubCmd)
+		}
+		this.subscriptions = []
+		this.subscribeVars = []
+
 		if (this.socket !== undefined) {
 			this.socket.destroy()
 		}
@@ -54,13 +62,12 @@ class TesiraInstance extends InstanceBase {
 			this.TIMER_POLLING = null
 		}
 
-		// Resolve any pending drain promise
+		// Clear queue first so doPolling doesn't log a spurious timeout warning
+		this.pollQueue = []
 		if (this.pollDrainResolver) {
 			this.pollDrainResolver()
 			this.pollDrainResolver = null
 		}
-		this.pollQueue = []
-		this.pollingInProgress = false
 
 		this.debugLog('Destroy')
 	}
@@ -114,6 +121,12 @@ class TesiraInstance extends InstanceBase {
 				// Match part of the response from unit when a connection is made.
 				if (line.match(/Welcome to the Tesira Text Protocol Server/)) {
 					this.updateStatus(InstanceStatus.Ok)
+
+					// Re-subscribe after Welcome banner — device is ready to accept commands
+					for (const sub of this.subscriptions) {
+						this.sendCommand(sub.cmd)
+						this.debugLog('Re-subscribed: ' + sub.cmd)
+					}
 				}
 
 				//capture subscription responses into custom variables (example:! "publishToken":"MyLevelCustomLabel" "value":-100.0000)
@@ -317,7 +330,7 @@ class TesiraInstance extends InstanceBase {
 				}
 
 				// Handle error responses so polling doesn't hang
-				if (this.pollQueue.length > 0 && line.match(/^-ERR/)) {
+				else if (this.pollQueue.length > 0 && line.match(/^-ERR/)) {
 					const currentPoll = this.pollQueue.shift()
 					this.log('error', 'Polling error response for ' + currentPoll.name + ': ' + line)
 
@@ -377,14 +390,16 @@ class TesiraInstance extends InstanceBase {
 
 			// Wait for all responses to come back or timeout
 			if (this.pollQueue.length > 0) {
+				let timeoutId
 				await Promise.race([
 					new Promise((resolve) => {
 						this.pollDrainResolver = resolve
 					}),
 					new Promise((resolve) => {
-						setTimeout(resolve, this.POLL_TIMEOUT_MS)
+						timeoutId = setTimeout(resolve, this.POLL_TIMEOUT_MS)
 					}),
 				])
+				clearTimeout(timeoutId)
 				this.pollDrainResolver = null
 
 				// Clear any remaining entries on timeout

--- a/index.js
+++ b/index.js
@@ -74,13 +74,9 @@ class TesiraInstance extends InstanceBase {
 
 	async configUpdated(config) {
 		this.config = config
-
-		if (this.TIMER_POLLING !== null) {
-			clearInterval(this.TIMER_POLLING)
-			this.TIMER_POLLING = null
-		}
-
-		this.TIMER_POLLING = setInterval(this.doPolling.bind(this), this.config.pollinginterval)
+		this.updateStatus(InstanceStatus.Connecting)
+		this.initTCP()
+		this.initPollingTCP()
 	}
 
 	initTCP() {

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class TesiraInstance extends InstanceBase {
 		this.customVars = []
 		this.pollingCmds = []
 		this.pollQueue = []
+		this.pollDrainResolver = null
 		this.pollingInProgress = false
 		this.POLL_TIMEOUT_MS = 5000
 		this.subscribeVars = []
@@ -53,9 +54,10 @@ class TesiraInstance extends InstanceBase {
 			this.TIMER_POLLING = null
 		}
 
-		// Resolve any pending poll promises
-		for (const entry of this.pollQueue) {
-			entry.resolver()
+		// Resolve any pending drain promise
+		if (this.pollDrainResolver) {
+			this.pollDrainResolver()
+			this.pollDrainResolver = null
 		}
 		this.pollQueue = []
 		this.pollingInProgress = false
@@ -307,14 +309,21 @@ class TesiraInstance extends InstanceBase {
 					}
 
 					this.setVariableValues(tmpVar)
-					currentPoll.resolver()
+
+					// Check if all responses received
+					if (this.pollQueue.length === 0 && this.pollDrainResolver) {
+						this.pollDrainResolver()
+					}
 				}
 
 				// Handle error responses so polling doesn't hang
 				if (this.pollQueue.length > 0 && line.match(/^-ERR/)) {
 					const currentPoll = this.pollQueue.shift()
-					this.debugLog('Polling error response for ' + currentPoll.name + ': ' + line)
-					currentPoll.resolver()
+					this.log('error', 'Polling error response for ' + currentPoll.name + ': ' + line)
+
+					if (this.pollQueue.length === 0 && this.pollDrainResolver) {
+						this.pollDrainResolver()
+					}
 				}
 				} // end for loop over lines
 			})
@@ -344,6 +353,12 @@ class TesiraInstance extends InstanceBase {
 		this.pollingInProgress = true
 
 		try {
+			if (this.poll_socket === undefined || !this.poll_socket.isConnected) {
+				this.log('error', 'Socket not connected :(')
+				return
+			}
+
+			// Send all commands at once
 			for (let i = 0; i < this.pollingCmds.length; i++) {
 				let pollCmd = this.pollingCmds[i]
 
@@ -352,37 +367,37 @@ class TesiraInstance extends InstanceBase {
 					continue
 				}
 
-				if (this.poll_socket === undefined || !this.poll_socket.isConnected) {
-					this.log('error', 'Socket not connected :(')
-					break
-				}
+				this.pollQueue.push({
+					name: pollCmd.varName,
+					roundVal: pollCmd.roundVal,
+				})
+				this.poll_socket.send(pollCmd.cmd + '\n')
+				this.debugLog('Sent polling command: ' + pollCmd.cmd)
+			}
 
-				const result = await Promise.race([
+			// Wait for all responses to come back or timeout
+			if (this.pollQueue.length > 0) {
+				await Promise.race([
 					new Promise((resolve) => {
-						this.pollQueue.push({
-							name: pollCmd.varName,
-							roundVal: pollCmd.roundVal,
-							resolver: resolve,
-						})
-						this.poll_socket.send(pollCmd.cmd + '\n')
-						this.debugLog('Sent polling command: ' + pollCmd.cmd)
+						this.pollDrainResolver = resolve
 					}),
 					new Promise((resolve) => {
-						setTimeout(() => resolve('TIMEOUT'), this.POLL_TIMEOUT_MS)
+						setTimeout(resolve, this.POLL_TIMEOUT_MS)
 					}),
 				])
+				this.pollDrainResolver = null
 
-				if (result === 'TIMEOUT') {
-					this.debugLog('Polling command timed out: ' + pollCmd.cmd)
-					const idx = this.pollQueue.findIndex((e) => e.name === pollCmd.varName)
-					if (idx > -1) {
-						this.pollQueue.splice(idx, 1)
-					}
+				// Clear any remaining entries on timeout
+				if (this.pollQueue.length > 0) {
+					this.log('warn', 'Polling timed out with ' + this.pollQueue.length + ' responses remaining')
+					this.pollQueue = []
 				}
+			}
 
-				if ('runOnce' in pollCmd) {
+			// Remove runOnce commands (reverse order to preserve indices)
+			for (let i = this.pollingCmds.length - 1; i >= 0; i--) {
+				if ('runOnce' in this.pollingCmds[i]) {
 					this.pollingCmds.splice(i, 1)
-					i--
 				}
 			}
 		} catch (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "biamp-tesira",
-	"version": "2.0.4-beta.5",
+	"version": "2.1.0",
 	"main": "index.js",
 	"scripts": {
 		"format": "prettier -w .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "biamp-tesira",
-	"version": "2.0.3",
+	"version": "2.0.4-beta.5",
 	"main": "index.js",
 	"scripts": {
 		"format": "prettier -w .",


### PR DESCRIPTION
  - Add **Subscribe to Parameter** and **Unsubscribe from Parameter** actions
    for real-time value updates without polling
  - Subscriptions auto-reconnect after connection loss
  - Batch all polling GET commands in a single burst instead of one at a time
  - Custom Command subscribe/unsubscribe now tracks subscriptions for reconnect
  - Fix `configUpdated` to reinitialize socket connections when settings change