### PR TITLE
Fix Tesira connection handling and secured login

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "companion-module-biamp-tesira",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"main": "dist/main.js",
 	"type": "module",
 	"scripts": {
@@ -10,6 +10,7 @@
 		"build": "rimraf dist && tsc -p tsconfig.build.json",
 		"build:main": "tsc -p tsconfig.build.json",
 		"dev": "tsc -p tsconfig.build.json --watch",
+		"test": "yarn build && node --test test/*.test.js",
 		"lint:raw": "eslint",
 		"lint": "eslint ."
 	},

--- a/src/connection-status.ts
+++ b/src/connection-status.ts
@@ -1,0 +1,6 @@
+export function formatConnectionStatus(commandReady: boolean, pollingReady: boolean): string {
+	if (commandReady && pollingReady) return 'Connected'
+	if (commandReady) return 'Control connected; polling unavailable'
+	if (pollingReady) return 'Polling connected; control unavailable'
+	return 'Disconnected'
+}

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -1,6 +1,7 @@
 import { combineRgb, type CompanionFeedbackContext, type CompanionFeedbackDefinitions } from '@companion-module/base'
 import { graphics } from 'companion-module-utils'
 import type { ModuleInstance } from './main.js'
+import { parseRangeOverrides } from './range-overrides.js'
 
 type MeterMode = 'vertical-bottom-up' | 'vertical-top-down' | 'horizontal-left-right'
 
@@ -63,22 +64,6 @@ function readRangeFromVariables(
 	const max = maxRaw !== undefined ? Number.parseFloat(maxRaw) : Number.NaN
 	if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) return undefined
 	return { min, max }
-}
-
-function parseRangeOverrides(raw: string): Map<string, { min: number; max: number }> {
-	const ranges = new Map<string, { min: number; max: number }>()
-	for (const entry of raw.split(/[\n;]/)) {
-		const trimmed = entry.trim()
-		if (!trimmed) continue
-		const [aliasPart, rangePart] = trimmed.split('=')
-		if (!aliasPart || !rangePart) continue
-		const [minPart, maxPart] = rangePart.split(':')
-		const min = Number(minPart)
-		const max = Number(maxPart)
-		if (!Number.isFinite(min) || !Number.isFinite(max) || min >= max) continue
-		ranges.set(aliasPart.trim(), { min, max })
-	}
-	return ranges
 }
 
 function readRangeOverride(self: ModuleInstance, alias: string | undefined): { min: number; max: number } | undefined {

--- a/src/login-prompt.ts
+++ b/src/login-prompt.ts
@@ -1,0 +1,10 @@
+export type LoginPrompt = 'username' | 'password'
+
+export function detectLoginPrompt(buffer: string): LoginPrompt | undefined {
+	const prompt = buffer.replace(/\r\0/g, '\n').replace(/\r/g, '\n').split('\n').pop()?.trim().toLowerCase()
+
+	if (!prompt) return undefined
+	if (/(?:^|\s)(?:login|username|user name|user):\s*$/.test(prompt)) return 'username'
+	if (/(?:^|\s)password:\s*$/.test(prompt)) return 'password'
+	return undefined
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { UpdateActions } from './actions.js'
 import { UpdateFeedbacks } from './feedbacks.js'
 import { UpdatePresets } from './presets.js'
 import { detectLoginPrompt } from './login-prompt.js'
+import { formatConnectionStatus } from './connection-status.js'
 
 interface TrackedSubscription {
 	cmd: string
@@ -311,14 +312,9 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 	}
 
 	updateVariables(): void {
-		const connectionStatus = this.isReady
-			? 'Connected'
-			: this.commandReady
-				? 'Control connected; polling unavailable'
-				: 'Disconnected'
 		const values: Record<string, string> = {
 			connected: this.isReady ? 'true' : 'false',
-			connection_status: connectionStatus,
+			connection_status: formatConnectionStatus(this.commandReady, this.pollingReady),
 			last_error: this.lastError,
 			last_command: this.lastCommand,
 			last_response: this.lastResponse,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { UpgradeScripts } from './upgrades.js'
 import { UpdateActions } from './actions.js'
 import { UpdateFeedbacks } from './feedbacks.js'
 import { UpdatePresets } from './presets.js'
+import { detectLoginPrompt } from './login-prompt.js'
 
 interface TrackedSubscription {
 	cmd: string
@@ -137,6 +138,8 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 
 	private socket: TelnetHelper | undefined
 	private pollSocket: TelnetHelper | undefined
+	private commandReady = false
+	private pollingReady = false
 	private pollTimer: NodeJS.Timeout | undefined
 	private levelHoldTimer: NodeJS.Timeout | undefined
 	private pollQueue: PendingPoll[] = []
@@ -308,9 +311,14 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 	}
 
 	updateVariables(): void {
+		const connectionStatus = this.isReady
+			? 'Connected'
+			: this.commandReady
+				? 'Control connected; polling unavailable'
+				: 'Disconnected'
 		const values: Record<string, string> = {
 			connected: this.isReady ? 'true' : 'false',
-			connection_status: this.isReady ? 'Connected' : 'Disconnected',
+			connection_status: connectionStatus,
 			last_error: this.lastError,
 			last_command: this.lastCommand,
 			last_response: this.lastResponse,
@@ -324,6 +332,34 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 		}
 
 		this.setVariableValues(values)
+	}
+
+	private syncConnectionStatus(status: InstanceStatus, message?: string): void {
+		const wasReady = this.isReady
+		this.isReady = this.commandReady && this.pollingReady
+
+		if (this.isReady) {
+			this.lastError = ''
+			this.updateStatus(InstanceStatus.Ok)
+		} else {
+			this.updateStatus(status, message)
+		}
+
+		this.updateVariables()
+		if (wasReady !== this.isReady) this.checkFeedbacks('connected')
+	}
+
+	private stopPollingTimer(): void {
+		if (this.pollTimer) {
+			clearInterval(this.pollTimer)
+			this.pollTimer = undefined
+		}
+	}
+
+	private startPollingTimer(): void {
+		this.stopPollingTimer()
+		this.pollTimer = setInterval(() => void this.doPolling(), Math.max(250, this.config.pollingInterval || 1000))
+		void this.doPolling()
 	}
 
 	async restartConnections(): Promise<void> {
@@ -363,10 +399,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 	}
 
 	async closeConnections(): Promise<void> {
-		if (this.pollTimer) {
-			clearInterval(this.pollTimer)
-			this.pollTimer = undefined
-		}
+		this.stopPollingTimer()
 		if (this.levelHoldTimer) {
 			clearInterval(this.levelHoldTimer)
 			this.levelHoldTimer = undefined
@@ -385,6 +418,10 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 			this.pollSocket = undefined
 		}
 
+		this.commandReady = false
+		this.pollingReady = false
+		this.isReady = false
+
 		this.pollQueue = []
 		if (this.pollDrainResolver) {
 			this.pollDrainResolver()
@@ -392,21 +429,23 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 		}
 	}
 
-	sendCommand(command: string): void {
-		if (!command) return
+	sendCommand(command: string): boolean {
+		if (!command) return false
 
 		this.lastCommand = command
 		this.updateVariables()
 
 		if (!this.socket?.isConnected) {
 			this.lastError = 'Command socket is not connected'
-			this.updateStatus(InstanceStatus.ConnectionFailure, this.lastError)
-			this.updateVariables()
-			return
+			this.commandReady = false
+			this.stopLevelHold()
+			this.syncConnectionStatus(InstanceStatus.ConnectionFailure, this.lastError)
+			return false
 		}
 
 		void this.socket.send(`${command}\n`)
 		this.log('debug', `Sent Tesira command: ${command}`)
+		return true
 	}
 
 	addPollingCommand(
@@ -446,12 +485,17 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 	): void {
 		this.stopLevelHold()
 
-		const sendAdjustment = (): void => {
-			this.sendCommand(buildCommandParts(instanceTag, command, 'level', channel, amount))
+		const sendAdjustment = (): boolean => {
+			return this.sendCommand(buildCommandParts(instanceTag, command, 'level', channel, amount))
 		}
 
-		sendAdjustment()
-		this.levelHoldTimer = setInterval(sendAdjustment, Math.max(50, intervalMs))
+		if (!sendAdjustment()) return
+		this.levelHoldTimer = setInterval(
+			() => {
+				if (!sendAdjustment()) this.stopLevelHold()
+			},
+			Math.max(50, intervalMs),
+		)
 	}
 
 	stopLevelHold(): void {
@@ -592,13 +636,36 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 
 		this.socket.on('status_change', (status: unknown, message: unknown) => {
 			this.log('debug', `Tesira command socket: ${String(status)} ${String(message)}`)
+			const detail = typeof message === 'string' ? message : undefined
+			if (status === InstanceStatus.Ok) {
+				this.syncConnectionStatus(InstanceStatus.Connecting, 'Waiting for command socket login')
+			} else if (status === InstanceStatus.Connecting) {
+				this.commandReady = false
+				this.stopLevelHold()
+				this.syncConnectionStatus(InstanceStatus.Connecting, detail)
+			} else if (status === InstanceStatus.Disconnected) {
+				this.commandReady = false
+				this.stopLevelHold()
+				this.syncConnectionStatus(InstanceStatus.Disconnected, detail ?? 'Command socket disconnected')
+			} else if (status === InstanceStatus.UnknownError) {
+				this.commandReady = false
+				this.stopLevelHold()
+				this.syncConnectionStatus(InstanceStatus.ConnectionFailure, detail)
+			}
 		})
 
 		this.socket.on('error', (error: Error) => {
 			this.lastError = error.message
-			this.isReady = false
-			this.updateStatus(InstanceStatus.ConnectionFailure, error.message)
-			this.updateVariables()
+			this.commandReady = false
+			this.stopLevelHold()
+			this.syncConnectionStatus(InstanceStatus.ConnectionFailure, error.message)
+		})
+
+		this.socket.on('end', () => {
+			this.lastError = 'Command socket disconnected'
+			this.commandReady = false
+			this.stopLevelHold()
+			this.syncConnectionStatus(InstanceStatus.Disconnected, this.lastError)
 		})
 
 		this.socket.on('data', (buffer: Buffer) => {
@@ -625,19 +692,57 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 
 		this.pollSocket.on('status_change', (status: unknown, message: unknown) => {
 			this.log('debug', `Tesira polling socket: ${String(status)} ${String(message)}`)
+			const detail = typeof message === 'string' ? message : undefined
+			if (status === InstanceStatus.Ok) {
+				this.syncConnectionStatus(
+					this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.Connecting,
+					'Waiting for polling socket login',
+				)
+			} else if (status === InstanceStatus.Connecting) {
+				this.pollingReady = false
+				this.stopPollingTimer()
+				this.syncConnectionStatus(
+					this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.Connecting,
+					detail ?? 'Polling socket reconnecting',
+				)
+			} else if (status === InstanceStatus.Disconnected || status === InstanceStatus.UnknownError) {
+				this.pollingReady = false
+				this.stopPollingTimer()
+				this.syncConnectionStatus(
+					this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.ConnectionFailure,
+					detail ?? 'Polling socket disconnected',
+				)
+			}
 		})
 
 		this.pollSocket.on('error', (error: Error) => {
-			this.lastError = error.message
+			this.lastError = `Polling socket: ${error.message}`
+			this.pollingReady = false
+			this.stopPollingTimer()
 			this.log('warn', `Tesira polling socket error: ${error.message}`)
-			this.updateStatus(InstanceStatus.ConnectionFailure, `Polling socket: ${error.message}`)
-			this.updateVariables()
+			this.syncConnectionStatus(
+				this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.ConnectionFailure,
+				this.lastError,
+			)
 		})
 
 		this.pollSocket.on('connect', () => {
-			if (this.pollTimer) clearInterval(this.pollTimer)
-			this.pollTimer = setInterval(() => void this.doPolling(), Math.max(250, this.config.pollingInterval || 1000))
-			void this.doPolling()
+			this.pollingReady = false
+			this.stopPollingTimer()
+			this.syncConnectionStatus(
+				this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.Connecting,
+				'Waiting for polling socket login',
+			)
+		})
+
+		this.pollSocket.on('end', () => {
+			this.lastError = 'Polling socket disconnected'
+			this.pollingReady = false
+			this.stopPollingTimer()
+			this.syncConnectionStatus(
+				this.commandReady ? InstanceStatus.UnknownWarning : InstanceStatus.Disconnected,
+				this.lastError,
+			)
 		})
 
 		this.pollSocket.on('data', (buffer: Buffer) => {
@@ -658,11 +763,10 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 	}
 
 	private respondToLoginPrompt(buffer: string, socket: TelnetHelper | undefined, socketName: string): string {
-		const prompt = buffer.replace(/\r\0/g, '\n').replace(/\r/g, '\n').split('\n').pop()?.trim().toLowerCase()
-
+		const prompt = detectLoginPrompt(buffer)
 		if (!prompt || !socket?.isConnected) return buffer
 
-		if (/^(login|username|user name|user):\s*$/.test(prompt)) {
+		if (prompt === 'username') {
 			const username = this.config.loginUsername?.trim() || 'default'
 			this.lastCommand = 'login username'
 			this.log('debug', `Sent Tesira ${socketName} socket login username`)
@@ -671,7 +775,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 			return ''
 		}
 
-		if (/^password:\s*$/.test(prompt)) {
+		if (prompt === 'password') {
 			const password = this.secrets.loginPassword ?? 'default'
 			this.lastCommand = 'login password'
 			this.log('debug', `Sent Tesira ${socketName} socket login password`)
@@ -688,9 +792,8 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 		if (this.config.logResponses) this.log('debug', `Tesira response: ${line}`)
 
 		if (line.includes('Welcome to the Tesira Text Protocol Server')) {
-			this.isReady = true
-			this.lastError = ''
-			this.updateStatus(InstanceStatus.Ok)
+			this.commandReady = true
+			this.syncConnectionStatus(InstanceStatus.UnknownWarning, 'Waiting for polling socket login')
 			if (this.config.autoFetchAliases) this.sendCommand('SESSION get aliases')
 			for (const subscription of this.trackedSubscriptions.values()) {
 				this.sendCommand(subscription.cmd)
@@ -731,7 +834,12 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 
 	private handlePollingLine(line: string): void {
 		if (this.config.logResponses) this.log('debug', `Tesira poll response: ${line}`)
-		if (line.includes('Welcome to the Tesira Text Protocol Server')) return
+		if (line.includes('Welcome to the Tesira Text Protocol Server')) {
+			this.pollingReady = true
+			this.syncConnectionStatus(InstanceStatus.Connecting)
+			this.startPollingTimer()
+			return
+		}
 
 		if (this.pollQueue.length === 0) return
 
@@ -979,7 +1087,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig, ModuleSecrets> {
 			this.pollingRerunRequested = true
 			return
 		}
-		if (!this.pollSocket?.isConnected) return
+		if (!this.pollSocket?.isConnected || !this.pollingReady) return
 		if (this.trackedPolling.size === 0) return
 
 		this.pollingInProgress = true

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,5 +1,6 @@
 import { combineRgb, type CompanionPresetDefinitions } from '@companion-module/base'
 import type { ModuleInstance } from './main.js'
+import { parseRangeOverrides } from './range-overrides.js'
 
 function sanitizeVariableName(value: string): string {
 	return value
@@ -46,25 +47,6 @@ function parsePairOverrides(raw: string): Map<string, string> {
 		const control = trimmed.slice(0, separatorIndex).trim()
 		const meter = trimmed.slice(separatorIndex + 1).trim()
 		if (control && meter) map.set(control, meter)
-	}
-	return map
-}
-
-function parseRangeOverrides(raw: string): Map<string, { min: number; max: number }> {
-	const map = new Map<string, { min: number; max: number }>()
-	for (const entry of raw.split(',')) {
-		const trimmed = entry.trim()
-		if (!trimmed) continue
-		const separatorIndex = trimmed.indexOf('=')
-		if (separatorIndex < 1) continue
-		const tag = trimmed.slice(0, separatorIndex).trim()
-		const rangePart = trimmed.slice(separatorIndex + 1).trim()
-		const [minRaw, maxRaw] = rangePart.split(':')
-		const min = Number.parseFloat(minRaw ?? '')
-		const max = Number.parseFloat(maxRaw ?? '')
-		if (tag && Number.isFinite(min) && Number.isFinite(max) && min < max) {
-			map.set(tag, { min, max })
-		}
 	}
 	return map
 }

--- a/src/range-overrides.ts
+++ b/src/range-overrides.ts
@@ -1,0 +1,28 @@
+export interface LevelRange {
+	min: number
+	max: number
+}
+
+export function parseRangeOverrides(raw: string): Map<string, LevelRange> {
+	const ranges = new Map<string, LevelRange>()
+
+	for (const entry of raw.split(',')) {
+		const trimmed = entry.trim()
+		if (!trimmed) continue
+
+		const separatorIndex = trimmed.indexOf('=')
+		if (separatorIndex < 1) continue
+
+		const instanceTag = trimmed.slice(0, separatorIndex).trim()
+		const rangePart = trimmed.slice(separatorIndex + 1).trim()
+		const [minRaw, maxRaw] = rangePart.split(':')
+		const min = Number.parseFloat(minRaw ?? '')
+		const max = Number.parseFloat(maxRaw ?? '')
+
+		if (instanceTag && Number.isFinite(min) && Number.isFinite(max) && min < max) {
+			ranges.set(instanceTag, { min, max })
+		}
+	}
+
+	return ranges
+}

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -81,6 +81,15 @@ function remapActionSpecificOptions(action: CompanionMigrationAction): boolean {
 			if (options.variableName !== undefined) changed = stringifyOption(options, 'variableName') || changed
 			break
 		case 'subscribe_helper':
+			if (options.attribute !== undefined) {
+				options.templateId = 'custom'
+				options.customAttribute = options.attribute
+				delete options.attribute
+				changed = true
+			}
+			if (options.index1 !== undefined) changed = stringifyOption(options, 'index1') || changed
+			if (options.variableName !== undefined) changed = stringifyOption(options, 'variableName') || changed
+			break
 		case 'unsubscribe_helper':
 			if (options.index1 !== undefined) changed = stringifyOption(options, 'index1') || changed
 			if (options.variableName !== undefined) changed = stringifyOption(options, 'variableName') || changed

--- a/test/review-regressions.test.js
+++ b/test/review-regressions.test.js
@@ -6,6 +6,8 @@ import { parseRangeOverrides } from '../dist/range-overrides.js'
 import { detectLoginPrompt } from '../dist/login-prompt.js'
 // eslint-disable-next-line n/no-unpublished-import -- tests exercise the compiled module output
 import { UpgradeScripts } from '../dist/upgrades.js'
+// eslint-disable-next-line n/no-unpublished-import -- tests exercise the compiled module output
+import { formatConnectionStatus } from '../dist/connection-status.js'
 
 test('parses every documented comma-separated level range override', () => {
 	const ranges = parseRangeOverrides('Lobby_Level=-80:12, Podium_Level=-40:0')
@@ -79,4 +81,11 @@ test('recognizes both bare and device-prefixed Tesira login prompts', () => {
 test('only recognizes login prompts at the end of the current line', () => {
 	assert.equal(detectLoginPrompt('login: not a prompt'), undefined)
 	assert.equal(detectLoginPrompt('Welcome to the Tesira Text Protocol Server...'), undefined)
+})
+
+test('reports all command and polling connection states', () => {
+	assert.equal(formatConnectionStatus(false, false), 'Disconnected')
+	assert.equal(formatConnectionStatus(true, false), 'Control connected; polling unavailable')
+	assert.equal(formatConnectionStatus(false, true), 'Polling connected; control unavailable')
+	assert.equal(formatConnectionStatus(true, true), 'Connected')
 })

--- a/test/review-regressions.test.js
+++ b/test/review-regressions.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+// eslint-disable-next-line n/no-unpublished-import -- tests exercise the compiled module output
+import { parseRangeOverrides } from '../dist/range-overrides.js'
+// eslint-disable-next-line n/no-unpublished-import -- tests exercise the compiled module output
+import { detectLoginPrompt } from '../dist/login-prompt.js'
+// eslint-disable-next-line n/no-unpublished-import -- tests exercise the compiled module output
+import { UpgradeScripts } from '../dist/upgrades.js'
+
+test('parses every documented comma-separated level range override', () => {
+	const ranges = parseRangeOverrides('Lobby_Level=-80:12, Podium_Level=-40:0')
+
+	assert.deepEqual(ranges.get('Lobby_Level'), { min: -80, max: 12 })
+	assert.deepEqual(ranges.get('Podium_Level'), { min: -40, max: 0 })
+	assert.equal(ranges.size, 2)
+})
+
+test('ignores malformed and reversed level range overrides', () => {
+	const ranges = parseRangeOverrides('MissingRange=,Reversed=12:-80,Valid=-20:5')
+
+	assert.deepEqual([...ranges], [['Valid', { min: -20, max: 5 }]])
+})
+
+test('migrates the legacy subscription attribute into the custom attribute fields', () => {
+	const action = {
+		actionId: 'subscribeParameter',
+		options: {
+			instanceID: 'Lobby_Level',
+			attribute: 'level',
+			index: 1,
+			customvar: 'lobby_level',
+		},
+	}
+
+	const result = UpgradeScripts[0](
+		{},
+		{
+			config: {},
+			secrets: undefined,
+			actions: [action],
+			feedbacks: [],
+		},
+	)
+
+	assert.equal(result.updatedActions.length, 1)
+	assert.equal(action.actionId, 'subscribe_helper')
+	assert.deepEqual(action.options, {
+		instanceTag: 'Lobby_Level',
+		templateId: 'custom',
+		customAttribute: 'level',
+		index1: '1',
+		variableName: 'lobby_level',
+	})
+})
+
+test('keeps the legacy unsubscribe attribute unchanged', () => {
+	const action = {
+		actionId: 'unsubscribeParameter',
+		options: {
+			attribute: 'mute',
+			index: 1,
+			customvar: 'lobby_mute',
+		},
+	}
+
+	UpgradeScripts[0]({}, { config: {}, secrets: undefined, actions: [action], feedbacks: [] })
+
+	assert.equal(action.actionId, 'unsubscribe_helper')
+	assert.equal(action.options.attribute, 'mute')
+})
+
+test('recognizes both bare and device-prefixed Tesira login prompts', () => {
+	assert.equal(detectLoginPrompt('login: '), 'username')
+	assert.equal(detectLoginPrompt('HomeStudioTesira login: '), 'username')
+	assert.equal(detectLoginPrompt('TesiraServerFeldmanBallRoom login: '), 'username')
+	assert.equal(detectLoginPrompt('Password: '), 'password')
+})
+
+test('only recognizes login prompts at the end of the current line', () => {
+	assert.equal(detectLoginPrompt('login: not a prompt'), undefined)
+	assert.equal(detectLoginPrompt('Welcome to the Tesira Text Protocol Server...'), undefined)
+})


### PR DESCRIPTION
## Summary

- track command and polling socket readiness independently and report partial connection states
- stop polling and held-level timers when their sockets disconnect
- share level-range override parsing between presets and feedbacks
- migrate legacy subscription attributes into the v3 custom subscription fields
- accept device-prefixed Tesira login prompts, such as `<device-name> login:`
- add regression tests for the review fixes and secured login parsing
- bump the module version to 3.0.4

## Root cause

Secured Tesira systems prefix the username prompt with the configured device name. The module only matched a bare `login:` prompt, so it never sent the configured username. Connection readiness also previously followed transport state rather than successful authentication on both sockets.

## Validation

- `yarn test` (6 tests passed)
- `yarn lint`
- `yarn companion-module-check`
- `git diff --check`
- authenticated successfully against a password-protected Tesira and received the Tesira Text Protocol welcome banner

Fixes #41